### PR TITLE
add sdm context manager and bdf inspection if no bdf present

### DIFF
--- a/sdmpy/bdf.py
+++ b/sdmpy/bdf.py
@@ -7,7 +7,8 @@
 # originally by Peter Williams.  So far this is somewhat targeted
 # to EVLA/WIDAR data files, it may not handle all the ALMA variants.
 
-from lxml import etree, objectify
+import logging
+logger = logging.getLogger(__name__)
 
 import os
 import sys
@@ -17,6 +18,7 @@ import mmap
 import math
 import numpy
 from copy import deepcopy
+from lxml import etree, objectify
 
 try:
     from progressbar import ProgressBar
@@ -73,6 +75,7 @@ class BDF(object):
             self.fp = open(fname, 'r')
         except IOError:
             self.fp = None
+            logger.warn('No BDF file found at {0}'.format(fname))
         else:
             self.mmdata = mmap.mmap(self.fp.fileno(), 0, mmap.MAP_PRIVATE,
                                     mmap.PROT_READ)

--- a/sdmpy/bdf.py
+++ b/sdmpy/bdf.py
@@ -75,7 +75,6 @@ class BDF(object):
             self.fp = open(fname, 'r')
         except IOError:
             self.fp = None
-            logger.warn('No BDF file found at {0}'.format(fname))
         else:
             self.mmdata = mmap.mmap(self.fp.fileno(), 0, mmap.MAP_PRIVATE,
                                     mmap.PROT_READ)
@@ -153,6 +152,9 @@ class BDF(object):
                 full_mime = MIMEPart(self.fp,
                                      recurse=True, binary_size=self.bin_size)
                 self.mime_ints = full_mime.body[1:]
+        else:
+            logger.warn('No BDF file found at {0}'.format(self.fname))
+
 
     def _raw(self,idx):
         if self.fp:
@@ -166,6 +168,7 @@ class BDF(object):
                                            recurse=True)
             return self.mime_ints[idx]
         else:
+            logger.warn('No BDF file found at {0}'.format(self.fname))
             return None
 
     @property

--- a/sdmpy/sdm.py
+++ b/sdmpy/sdm.py
@@ -54,10 +54,15 @@ class SDM(object):
         """Return a Scan object for the given scan number."""
         return Scan(self,str(idx))
 
-    def scans(self):
+    def scans(self, bdfonly=False):
         """Iterate over scans."""
         # List of SDM scan numbers:
-        scanidx = [s.scanNumber for s in self['Scan']]
+        if bdfonly:
+            scanidx = [s.scanNumber for s in self['Scan']
+                       if self.scan(s.scanNumber).bdf.exists]
+        else:
+            scanidx = [s.scanNumber for s in self['Scan']]
+
         for idx in scanidx:
             yield self.scan(idx)
 

--- a/sdmpy/sdm.py
+++ b/sdmpy/sdm.py
@@ -85,6 +85,12 @@ class SDM(object):
         # Call each table's write method for the rest
         for tab in self.tables: self[tab].write(newpath)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
 def sdmtable(name,path,*args,**kwargs):
     """
     Return the correct type of SDM table object (binary or XML).

--- a/sdmpy/sdm.py
+++ b/sdmpy/sdm.py
@@ -54,8 +54,8 @@ class SDM(object):
         """Return a Scan object for the given scan number."""
         return Scan(self,str(idx))
 
-    def scans(self, hasbdf=True):
-        """Iterate over scans."""
+    def scans(self, hasbdf=False):
+        """Iterate over scans.  Set hasbdf=True to only return scans for which BDFs exist."""
         # List of SDM scan numbers:
         if hasbdf:
             scanidx = [s.scanNumber for s in self['Scan']

--- a/sdmpy/sdm.py
+++ b/sdmpy/sdm.py
@@ -54,10 +54,10 @@ class SDM(object):
         """Return a Scan object for the given scan number."""
         return Scan(self,str(idx))
 
-    def scans(self, bdfonly=False):
+    def scans(self, hasbdf=True):
         """Iterate over scans."""
         # List of SDM scan numbers:
-        if bdfonly:
+        if hasbdf:
             scanidx = [s.scanNumber for s in self['Scan']
                        if self.scan(s.scanNumber).bdf.exists]
         else:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'sdmpy',
-    version='1.36',
+    version='1.4',
     description='Python for ALMA/VLA Science Data Model',
     author='Paul Demorest',
     author_email='pdemores@nrao.edu',


### PR DESCRIPTION
A few things bundled here. The context manager is a tiny change, but I wanted to support more interaction with the bdf objects in the case where no bdf is present (see #8).
Now the instantiation of the bdf will use try/except and fills some fields with None if no bdf is present. I also added a bdf.exists property to simplify testing for bdf presence.