### PR TITLE
bdf_average script has option to flag integrations with high zerofraction

### DIFF
--- a/scripts/bdf_average.py
+++ b/scripts/bdf_average.py
@@ -18,7 +18,7 @@ par.add_argument("-e", "--ext", default="avg",
         help="extension to add to output SDM [%(default)s]")
 par.add_argument("-b", "--bdfdir", default="",
         help="path to BDFs (optional)")
-par.add_argument("-f", "--flagfrac", default=1.0,
+par.add_argument("-f", "--flagfrac", default=1.0, type=float,
         help="Flag integrations with zero fraction greater than flagfrac")
 args = par.parse_args()
 
@@ -76,8 +76,8 @@ for scan in sdm.scans():
             bdfint.data[dtype] /= count[dtype]
             bdfint.data[dtype][np.where(count[dtype]==0.0)] = 0.0
             if zerofrac > args.flagfrac:
-                bdfint.data[dtype] = 0.0  # flag data if zeros exceed limit
-                zeroed += 0
+                bdfint.data[dtype][:] = 0.0  # flag data if zeros exceed limit
+                zeroed += 1
 
         # update timestamp and interval
         bdfint.sdmDataSubsetHeader.schedulePeriodTime.time += delta_t
@@ -85,8 +85,8 @@ for scan in sdm.scans():
         bdfout.write_integration(bdfint)
     bdfout.close()
 
-    if args.flagfrac < 1.:
-        print("Flagged {0} integrations for zerofrac exceeding flagfrac")
+    if zeroed:
+        print("Flagged {0} integrations for zerofrac exceeding flagfrac.".format(zeroed))
 
     # update SDM entries with corect number of integrations, etc.
     scan._main.numIntegration = nout

--- a/scripts/bdf_average.py
+++ b/scripts/bdf_average.py
@@ -33,9 +33,9 @@ os.mkdir(sdmout)
 os.mkdir(bdfoutpath)
 
 for scan in sdm.scans():
-    print "Processing '%s' scan %s:" % (sdmname, scan.idx)
+    print("Processing '{0}' scan {1}:".format(sdmname, scan.idx))
     if scan.bdf.fp is None:
-        print "Error reading bdf for scan %s, skipping" % (scan.idx,)
+        print("Error reading bdf for scan {0}, skipping".format(scan.idx))
         continue
 
     bdf = scan.bdf
@@ -44,7 +44,7 @@ for scan in sdm.scans():
     # Also this assumes averaging time is the same during the whole
     # BDF.  This is always true for VLA data.
     bdfoutname = bdfoutpath + '/' + os.path.basename(scan.bdf_fname)
-    navg = int(tavg / bdf[0].interval)
+    navg = max(1, int(tavg / bdf[0].interval))
     nout = int(bdf.numIntegration / navg)
     delta_t = int((navg/2.0)*bdf[0].interval*1e9) # ns
     # Set up for output BDF, copying header info from the input BDF

--- a/scripts/bdf_average.py
+++ b/scripts/bdf_average.py
@@ -18,11 +18,15 @@ par.add_argument("-e", "--ext", default="avg",
         help="extension to add to output SDM [%(default)s]")
 par.add_argument("-b", "--bdfdir", default="",
         help="path to BDFs (optional)")
+par.add_argument("-f", "--flagfrac", default=1.0,
+        help="Flag integrations with zero fraction greater than flagfrac")
 args = par.parse_args()
 
 sdmname = args.sdmname.rstrip('/')
 
 sdm = sdmpy.SDM(sdmname,bdfdir=args.bdfdir)
+
+assert (args.flagfrac >= 0.) and (args.flagfrac <= 1.)
 
 tavg = args.time # in seconds
 
@@ -58,14 +62,21 @@ for scan in sdm.scans():
             bdfint.data[dtype] = bdfint.data[dtype].copy()
             count[dtype] = np.zeros(bdfint.data[dtype].shape)
             count[dtype] += bdfint.data[dtype] != 0.0
-        for j in range(1,navg):
+        zerofrac = 0.
+        for j in range(1, navg):
+            if args.flagfrac < 1.0:
+                zerofrac += bdf[i*navg+j].zerofraction()  # default looks at cross
             for dtype in bdfint.data.keys():
                 dat = bdf[i*navg+j].data[dtype]
                 bdfint.data[dtype] += dat
                 count[dtype] += dat != 0.0
+        zerofrac /= navg
         for dtype in bdfint.data.keys():
             bdfint.data[dtype] /= count[dtype]
             bdfint.data[dtype][np.where(count[dtype]==0.0)] = 0.0
+            if zerofrac > args.flagfrac:
+                bdfint.data[dtype] = 0.0  # flag data if zeros exceed limit
+
         # update timestamp and interval
         bdfint.sdmDataSubsetHeader.schedulePeriodTime.time += delta_t
         bdfint.sdmDataSubsetHeader.schedulePeriodTime.interval *= navg

--- a/scripts/bdf_average.py
+++ b/scripts/bdf_average.py
@@ -55,6 +55,7 @@ for scan in sdm.scans():
     bdfout = sdmpy.bdf.BDFWriter(bdfoutpath, fname=os.path.basename(scan.bdf_fname), bdf=bdf)
     bdfout.write_header()
     bar = progressbar.ProgressBar()
+    zeroed = 0
     for i in bar(range(nout)):
         bdfint = bdf[i*navg]
         count = {}
@@ -76,12 +77,16 @@ for scan in sdm.scans():
             bdfint.data[dtype][np.where(count[dtype]==0.0)] = 0.0
             if zerofrac > args.flagfrac:
                 bdfint.data[dtype] = 0.0  # flag data if zeros exceed limit
+                zeroed += 0
 
         # update timestamp and interval
         bdfint.sdmDataSubsetHeader.schedulePeriodTime.time += delta_t
         bdfint.sdmDataSubsetHeader.schedulePeriodTime.interval *= navg
         bdfout.write_integration(bdfint)
     bdfout.close()
+
+    if args.flagfrac < 1.:
+        print("Flagged {0} integrations for zerofrac exceeding flagfrac")
 
     # update SDM entries with corect number of integrations, etc.
     scan._main.numIntegration = nout

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email='pdemores@nrao.edu',
     url='http://github.com/demorest/sdmpy',
     packages=find_packages(),        # get all python scripts in realtime
-    install_requires=['lxml', 'numpy', 'future'],
+    install_requires=['lxml', 'numpy', 'future', 'progressbar'],
     package_data={'sdmpy': ['xsd/*.xsd']},
     scripts=['scripts/bdf_average.py',
              'scripts/bdf_bin_split.py',


### PR DESCRIPTION
New parameter `--flagfrac` will flag integrations that have an average `zerofrac` higher than `flagfrac`. It also logs number of flagged integrations.